### PR TITLE
allocator: correctness fixes, robust free-list ops, next-fit wrap, perf hints; plus build/doc housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,7 @@ release/
 debug/
 bin/
 docs/
+doxygen/doxygen-awesome
 
 # System Files
 .DS_Store

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -561,8 +561,8 @@ static void *MEM_growUserHeap(mem_allocator_t *const allocator,
  *  @retval -EIO:             mmap() failed.
  *  @retval -ENOMEM:          Allocation of mmap_t metadata failed.
  * ========================================================================== */
-static int *MEM_mapAlloc(mem_allocator_t *const allocator,
-                         const size_t           total_size);
+static void *MEM_mapAlloc(mem_allocator_t *const allocator,
+                          const size_t           total_size);
 
 /** ============================================================================
  *  @brief  Unmaps a previously mapped memory region and removes its
@@ -1795,8 +1795,8 @@ function_output:
  *  @retval -EIO:             mmap() failed.
  *  @retval -ENOMEM:          Allocation of mmap_t metadata failed.
  * ========================================================================== */
-static int *MEM_mapAlloc(mem_allocator_t *const allocator,
-                         const size_t           total_size)
+static void *MEM_mapAlloc(mem_allocator_t *const allocator,
+                          const size_t           total_size)
 {
   void *ptr = (void *)NULL;
 

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -2274,7 +2274,7 @@ static int MEM_splitBlock(mem_allocator_t *const allocator,
 
   aligned_size = ALIGN(req_size);
   total_size
-    = (size_t)(aligned_size + sizeof(block_header_t) + sizeof(uint32_t));
+    = (size_t)(aligned_size + sizeof(block_header_t) + sizeof(uintptr_t));
 
   if (block->size < total_size + MIN_BLOCK_SIZE)
   {

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -193,7 +193,7 @@
 #elif ARCH_ALIGNMENT == 4
   #define PREFETCH_MULT (uintptr_t)(0x01010101U)
 #elif ARCH_ALIGNMENT == 1
-  #define CANARY_VALUE (uintptr_t)(0x01U)
+  #define PREFETCH_MULT (uintptr_t)(0x01U)
 #else
   #error "Unsupported ARCH_ALIGNMENT for PREFETCH_MULT"
 #endif

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -2392,7 +2392,9 @@ static int MEM_mergeBlocks(mem_allocator_t *const allocator,
     ret = -EINVAL;
     LOG_ERROR("Invalid parameters: allocator=%p, block=%p. "
               "Error code: %d.\n",
-              (void *)allocator, (void *)block, ret);
+              (void *)allocator,
+              (void *)block,
+              ret);
     goto function_output;
   }
 
@@ -2454,7 +2456,8 @@ static int MEM_mergeBlocks(mem_allocator_t *const allocator,
       if (block->next)
         block->next->prev = prev_block;
 
-      canary_addr  = (uintptr_t)prev_block + prev_block->size - sizeof(uintptr_t);
+      canary_addr
+        = (uintptr_t)prev_block + prev_block->size - sizeof(uintptr_t);
       data_canary  = (uintptr_t *)canary_addr;
       *data_canary = CANARY_VALUE;
 
@@ -2547,8 +2550,7 @@ static void *MEM_allocatorMalloc(mem_allocator_t *const      allocator,
   }
 
   total_size = ALIGN(size) + sizeof(block_header_t) + sizeof(uintptr_t);
-
-  arena = &allocator->arenas[0];
+  arena      = &allocator->arenas[0];
 
   if (size > MMAP_THRESHOLD)
   {
@@ -2556,8 +2558,7 @@ static void *MEM_allocatorMalloc(mem_allocator_t *const      allocator,
     if (raw_mmap == NULL)
     {
       user_ptr = PTR_ERR(-ENOMEM);
-      LOG_ERROR("Mmap failed: grow heap by %zu bytes. "
-                "Error code: %d.\n",
+      LOG_ERROR("Mmap failed: %zu bytes. Error code: %d.\n",
                 total_size,
                 (int)(intptr_t)user_ptr);
       goto function_output;
@@ -2567,8 +2568,8 @@ static void *MEM_allocatorMalloc(mem_allocator_t *const      allocator,
 
     block->magic  = MAGIC_NUMBER;
     block->size   = total_size;
-    block->free   = 0;
-    block->marked = 0;
+    block->free   = 0u;
+    block->marked = 0u;
     block->next   = (block_header_t *)NULL;
     block->prev   = (block_header_t *)NULL;
     block->canary = CANARY_VALUE;
@@ -2583,7 +2584,6 @@ static void *MEM_allocatorMalloc(mem_allocator_t *const      allocator,
 
     LOG_INFO("Mmap used for alloc: %p (%zu bytes).\n", raw_mmap, size);
     user_ptr = (uint8_t *)raw_mmap + sizeof(block_header_t);
-
     goto function_output;
   }
 
@@ -2606,8 +2606,8 @@ static void *MEM_allocatorMalloc(mem_allocator_t *const      allocator,
 
     block->magic  = MAGIC_NUMBER;
     block->size   = total_size;
-    block->free   = 1;
-    block->marked = 0;
+    block->free   = 1u;
+    block->marked = 0u;
     block->next   = (block_header_t *)NULL;
     block->prev   = (block_header_t *)NULL;
     block->canary = CANARY_VALUE;
@@ -2617,11 +2617,7 @@ static void *MEM_allocatorMalloc(mem_allocator_t *const      allocator,
     *data_canary = CANARY_VALUE;
 
     block->fl_next = (block_header_t *)NULL;
-    block->fl_next = (block_header_t *)NULL;
-
-    ret = MEM_removeFreeBlock(allocator, block);
-    if (ret != EXIT_SUCCESS)
-      goto function_output;
+    block->fl_prev = (block_header_t *)NULL;
 
     ret = MEM_insertFreeBlock(allocator, block);
     if (ret != EXIT_SUCCESS)

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -2112,7 +2112,8 @@ static int MEM_findNextFit(mem_allocator_t *const allocator,
 
     current = (current->next)
                 ? current->next
-                : (block_header_t *)(void *)(uintptr_t)allocator->heap_start;
+                : (block_header_t *)((uint8_t *)allocator->heap_start
+                                     + allocator->metadata_size);
   } while (current != start);
 
   ret = -ENOMEM;

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -2171,8 +2171,11 @@ static int MEM_findNextFit(mem_allocator_t *const allocator,
 
     current = (current->next)
                 ? current->next
-                : (block_header_t *)((uint8_t *)allocator->heap_start
-                                     + allocator->metadata_size);
+               : (block_header_t *)ASSUME_ALIGNED(
+                      (uint8_t *)allocator->heap_start
+                      + allocator->metadata_size,
+                      ARCH_ALIGNMENT);
+
   } while (current != start);
 
   ret = -ENOMEM;

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -2965,15 +2965,11 @@ static int MEM_allocatorFree(mem_allocator_t *const allocator,
 
       goto function_output;
     }
+    else
+    {
+      (void)MEM_insertFreeBlock(allocator, block);
+    }
   }
-
-  ret = MEM_removeFreeBlock(allocator, block);
-  if (ret != EXIT_SUCCESS)
-    goto function_output;
-
-  ret = MEM_insertFreeBlock(allocator, block);
-  if (ret != EXIT_SUCCESS)
-    goto function_output;
 
   freed_size = (size_t)(block->size - sizeof(*block) - sizeof(uintptr_t));
   LOG_INFO("Memory freed: addr: %p (%zu bytes).\n", ptr, freed_size);

--- a/src/libmemalloc.c
+++ b/src/libmemalloc.c
@@ -2169,12 +2169,12 @@ static int MEM_findNextFit(mem_allocator_t *const allocator,
       goto function_output;
     }
 
-    current = (current->next)
-                ? current->next
-               : (block_header_t *)ASSUME_ALIGNED(
-                      (uint8_t *)allocator->heap_start
-                      + allocator->metadata_size,
-                      ARCH_ALIGNMENT);
+    current
+      = (current->next)
+          ? current->next
+          : (block_header_t *)ASSUME_ALIGNED((uint8_t *)allocator->heap_start
+                                               + allocator->metadata_size,
+                                             ARCH_ALIGNMENT);
 
   } while (current != start);
 


### PR DESCRIPTION
---

## Summary

This PR consolidates a series of allocator fixes and small developer-experience improvements:

- Correct return type for `MEM_mapAlloc()` (now `void *`).
- Fix canary sizing and placement in `MEM_splitBlock()` (use `sizeof(uintptr_t)`), and re-arm canaries on full-block consumption.
- Repair `PREFETCH_MULT` for `ARCH_ALIGNMENT==1` (avoid clobbering `CANARY_VALUE`).
- Harden free-list manipulation in `MEM_mergeBlocks()`, `MEM_allocatorMalloc()` (post-grow path), and `MEM_allocatorFree()` (avoid double churn; restore on shrink failure).
- Make **NEXT_FIT** wrap to the **first user block** (not heap base).
- Add portable perf/portability helpers for memops: `PREFETCH_R/W`, `ASSUME_ALIGNED`, `LIKELY/UNLIKELY` fallbacks, and a safe `__has_builtin` fallback.
- Housekeeping: ignore vendored Doxygen theme; add `--clear` build flag for hard clean.

**No ABI impact.**

---

## Motivation

Several correctness issues could corrupt free lists, misplace canaries on 64-bit, or cause false corruption when NEXT_FIT wrapped into metadata. At the same time, memops hot paths benefit from prefetch/alignment hints, but need clean fallbacks to remain portable across compilers/targets. The build and docs tweaks keep the tree tidy and workflows simple.

---

## Changes in Detail

### Allocation & Block Integrity
- **`MEM_mapAlloc()`**: return `void *` (match `mmap()` + ERR_PTR pattern; remove misleading `int *` type).
- **`MEM_splitBlock()`**:
  - Use `sizeof(uintptr_t)` for the trailing canary in `total_size`.
  - Remove once up-front; if consuming full block, arm header/data canaries before returning.
  - On split, arm allocated part and insert only the remainder.
- **`PREFETCH_MULT` (`ARCH_ALIGNMENT==1`)**: define the correct repeating-byte mask; do not redefine `CANARY_VALUE`.

### Free-List Robustness
- **`MEM_mergeBlocks()`**: do not remove the current block at entry; remove/merge neighbors only when free and valid; re-arm trailing canary after each merge; insert the consolidated block exactly once.
- **`MEM_allocatorMalloc()` (grow path)**: initialize `fl_next/fl_prev` to `NULL`; insert the newly grown block once, then re-run `find()`; drop removal of a block not yet inserted.
- **`MEM_allocatorFree()`**: trust `MEM_mergeBlocks()` to (re)insert; only unlink when shrinking; if `sbrk()` shrink fails, **reinsert immediately**; drop unconditional tail remove/insert.

### Placement Strategy
- **NEXT_FIT wrap**: wrap to `(uint8_t *)allocator->heap_start + allocator->metadata_size` (first user block) to avoid scanning allocator metadata and to align with `setInitialMarks()` / `gcSweep()` heap traversal.

### Performance & Portability
- **Memops helpers**:
  - `PREFETCH_R(addr)` / `PREFETCH_W(addr)` wrap `__builtin_prefetch` (no-op otherwise).
  - `ASSUME_ALIGNED(ptr, align)` wraps `__builtin_assume_aligned` (passthrough otherwise).
  - `LIKELY(x)` / `UNLIKELY(x)` via `__builtin_expect` with safe fallbacks.
  - Provide fallback for `__has_builtin`.
- Apply helpers in `MEM_memset()` / `MEM_memcpy()` to keep loops readable, hintable, and portable.

### Housekeeping
- **`.gitignore`**: ignore `doxygen/doxygen-awesome/`.
- **Build**: `--clear` flag to purge `./bin ./build ./docs ./doxygen` and exit; update usage.

---

## Risks & Mitigations

- `ASSUME_ALIGNED` is UB if the promise is false; used only where alignment is guaranteed by design.
- Prefetch hints are advisory; fallbacks ensure no semantic change on compilers without builtins.

---

Signed-off-by: Rafael V. Volkmer <rafael.v.volkmer@gmail.com>