### PR TITLE
Allocator Hardening – Validation & Shrink FixesDevelop

### DIFF
--- a/inc/libmemalloc.h
+++ b/inc/libmemalloc.h
@@ -476,6 +476,8 @@ typedef struct __ALIGN GcThread
  *    @li @b arenas           – Array of arena metadata
  *    @li @b mmap_list        – Linked list of mmap’d regions
  *    @li @b free_lists       – Segregated free lists by size class
+ *    @li @b last_brk_start   – Start address of the last sbrk(+) lease
+ *    @li @b last_brk_end     – End (exclusive) of the last sbrk(+) lease
  *    @li @b gc_thread        – Garbage collector controller
  * ========================================================================== */
 typedef struct __ALIGN MemoryAllocator
@@ -497,7 +499,10 @@ typedef struct __ALIGN MemoryAllocator
   mem_arena_t *arenas;             /**< Array of arena metadata */
   mmap_t      *mmap_list;          /**< Linked list of mmap’d regions */
 
-  gc_thread_t gc_thread;           /**< Garbage collector controller */
+  uint8_t *last_brk_start; /**< Start address of the last sbrk(+) lease */
+  uint8_t *last_brk_end;   /**< End (exclusive) of the last sbrk(+) lease */
+
+  gc_thread_t gc_thread;   /**< Garbage collector controller */
 } mem_allocator_t;
 
 /** ============================================================================


### PR DESCRIPTION
---

## Summary

This PR hardens allocator validation and heap shrinking logic to prevent false corruption reports and unsafe memory trims:

- **`MEM_validateBlock()`**: gate canary checks behind a fully verified header; reject implausible addresses/headers early with `-ENOENT` (WARNING) or `-EFAULT` (ERROR).
- **`MEM_allocatorFree()` shrink path**: only call `sbrk(-X)` if the free tail block exactly spans the last contiguous lease; otherwise skip shrink safely.

**No ABI impact.**

---

## Motivation

The allocator was too eager to treat arbitrary addresses as valid blocks and to return memory with `sbrk(-X)` without proving alignment to the last lease.  
This could cause:

- **Noisy false-positive “Corrupted header” errors** during GC/stack scanning (e.g., zeroed memory, metadata, or foreign pointers).  
- **Unsafe shrink**: cutting into live memory or allocator metadata, later tripping canary/magic checks with `-EFAULT` / `-EPROTO`.  

The fixes add defensive plausibility gates and stricter shrink preconditions, making logs actionable and allocator behavior consistent.

---

## Changes in Detail

### Block Validation (`MEM_validateBlock`)

- **Region membership**: address must fall inside the managed heap or a tracked mmap range; else `-EFAULT` (**ERROR**).
- **Exclude allocator metadata**: heap addresses below `heap_start + metadata_size` are rejected as non-user blocks (`-ENOENT`, **WARNING**).
- **Alignment check**: header must be aligned to `ARCH_ALIGNMENT` before reading fields.
- **Header shape**: header must fully fit in region; require `size >= sizeof(block_header_t) + sizeof(uintptr_t)` and aligned.
- **Bounds check**: reject blocks where `(addr + size)` exceeds heap/mmap end.
- **Magic gate**: only consider a block valid if `magic == MAGIC_NUMBER`; otherwise classify as “not a memalloc block” (`-ENOENT`).
- **Canary checks only after header is validated**:
  - Heap: header/data canaries checked; mismatches → `-EPROTO` / `-EOVERFLOW` (**ERROR**).
  - Mmap: trailing canary must be in-bounds; mismatch → `-EOVERFLOW`.
- **Logging consistency**:
  - **ERROR**: real corruption or out-of-region.
  - **WARNING**: “not a memalloc block” rejections.
- Fix pointer arithmetic in mmap-boundary logs:  
  `(uint8_t *)map->addr + map->size`

---

### Heap Shrinking (`MEM_allocatorFree`)

Shrink only if:

- `sbrk(0) == allocator->heap_end` (OS break matches allocator).  
- `last_brk_end == heap_end` (we’re at the last lease).  
- Free block end == `heap_end`.  
- Free block size ≥ lease size.  

Additional changes:

- Remove the block from free list before shrink; on failure, reinsert immediately.  
- On success: update `heap_end`, clear `last_brk_*`, reset `last_allocated`.  

---

## Risks & Mitigations

- **Stricter checks** may classify some borderline cases as “not a memalloc block” (WARNING), but this is preferable to mis-reporting corruption.  
- **Conservative shrink**: may keep memory resident longer, but avoids unsafe trims and spurious canary errors.  

---

Signed-off-by: Rafael V. Volkmer <rafael.v.volkmer@gmail.com>